### PR TITLE
Add Table Sniffer extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Table Sniffer Chrome Extension
+
+This extension detects HTML tables on the active page and allows exporting them to CSV or copying to the clipboard for Excel.
+
+## Features
+
+- Lists visible tables on the current page
+- Preview table contents
+- Download as CSV or copy as TSV
+- Options for delimiter and line endings
+
+## Development
+
+Run the simple unit test:
+
+```bash
+node test/run.js
+```
+
+Load the extension in Chrome via `chrome://extensions` (Developer mode) and selecting this directory.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,7 @@
+{
+  "extName": {"message": "Table Sniffer"},
+  "extDescription": {"message": "Detect and export HTML tables to CSV or Excel clipboard."},
+  "preview": {"message": "Preview"},
+  "downloadCsv": {"message": "Download CSV"},
+  "copyExcel": {"message": "Copy for Excel"}
+}

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,69 @@
+(function() {
+  if (window.tableSnifferInitialized) return;
+  window.tableSnifferInitialized = true;
+
+  let detectedTables = [];
+  let highlightEl = null;
+
+  function detectTables(showHidden) {
+    detectedTables = [];
+    const tables = Array.from(document.querySelectorAll('table'));
+    let id = 0;
+    const infos = [];
+    tables.forEach(table => {
+      const visible = showHidden || (table.offsetWidth > 0 && table.offsetHeight > 0);
+      if (!visible) return;
+      const cellCount = table.querySelectorAll('th, td').length;
+      if (cellCount < 2) return;
+      table.dataset.tableSnifferId = id;
+      detectedTables.push(table);
+      const rows = table.rows.length;
+      const cols = table.rows[0] ? table.rows[0].cells.length : 0;
+      const preview = [];
+      for (let r = 0; r < Math.min(2, rows); r++) {
+        const row = [];
+        for (let c = 0; c < cols; c++) {
+          const cell = table.rows[r].cells[c];
+          row.push(cell ? cell.innerText.trim() : '');
+        }
+        preview.push(row);
+      }
+      infos.push({ id: id, rows, cols, preview });
+      id++;
+    });
+    return infos;
+  }
+
+  function getTableData(id) {
+    const table = detectedTables[id];
+    if (!table) return null;
+    const data = [];
+    for (const row of table.rows) {
+      const rowData = [];
+      for (const cell of row.cells) {
+        rowData.push(cell.innerText.trim());
+      }
+      data.push(rowData);
+    }
+    return data;
+  }
+
+  function highlightTable(id) {
+    if (highlightEl) highlightEl.style.outline = '';
+    const table = detectedTables[id];
+    if (table) {
+      highlightEl = table;
+      table.style.outline = '2px solid orange';
+    }
+  }
+
+  chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg.action === 'getTables') {
+      sendResponse(detectTables(msg.showHidden));
+    } else if (msg.action === 'getTableData') {
+      sendResponse(getTableData(msg.id));
+    } else if (msg.action === 'highlightTable') {
+      highlightTable(msg.id);
+    }
+  });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "__MSG_extName__",
+  "description": "__MSG_extDescription__",
+  "version": "1.0.0",
+  "manifest_version": 3,
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["activeTab", "downloads", "clipboardWrite", "storage", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "options_page": "options.html",
+  "default_locale": "en"
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+  <label><input type="checkbox" id="detectOnClickOnly"> Detect tables only when extension clicked</label><br>
+  <label><input type="checkbox" id="showHiddenTables"> Show hidden tables</label><br>
+  <label>Delimiter: <select id="delimiter"><option value=",">Comma (,)</option><option value=";">Semicolon (;)</option></select></label><br>
+  <label>Line endings: <select id="lineEnding"><option value="\n">LF</option><option value="\r\n">CRLF</option></select></label><br>
+  <button id="save">Save</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const detect = document.getElementById('detectOnClickOnly');
+  const showHidden = document.getElementById('showHiddenTables');
+  const delimiter = document.getElementById('delimiter');
+  const lineEnding = document.getElementById('lineEnding');
+
+  chrome.storage.sync.get({
+    detectOnClickOnly: false,
+    showHiddenTables: false,
+    delimiter: ',',
+    lineEnding: '\n'
+  }, items => {
+    detect.checked = items.detectOnClickOnly;
+    showHidden.checked = items.showHiddenTables;
+    delimiter.value = items.delimiter;
+    lineEnding.value = items.lineEnding;
+  });
+
+  document.getElementById('save').addEventListener('click', () => {
+    chrome.storage.sync.set({
+      detectOnClickOnly: detect.checked,
+      showHiddenTables: showHidden.checked,
+      delimiter: delimiter.value,
+      lineEnding: lineEnding.value
+    }, () => {
+      alert('Options saved');
+    });
+  });
+});

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,7 @@
+body { font-family: sans-serif; margin: 10px; width: 300px; }
+#table-list { list-style: none; padding: 0; }
+#table-list li { margin-bottom: 5px; }
+button { margin-left: 5px; }
+#preview-table { border-collapse: collapse; max-height: 150px; overflow: auto; }
+#preview-table td { border: 1px solid #ccc; padding: 2px 4px; }
+.buttons { margin-top: 5px; }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <ul id="table-list"></ul>
+  <div id="preview-container" hidden>
+    <table id="preview-table"></table>
+    <div class="buttons">
+      <button id="download"></button>
+      <button id="copy"></button>
+    </div>
+  </div>
+  <script src="util.js"></script>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,89 @@
+let currentTabId = null;
+let currentTableId = null;
+let options = {
+  delimiter: ',',
+  lineEnding: '\n',
+  showHiddenTables: false
+};
+
+function loadOptions() {
+  return new Promise(resolve => {
+    chrome.storage.sync.get(options, items => {
+      options = Object.assign(options, items);
+      resolve();
+    });
+  });
+}
+
+function requestTables() {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    const tab = tabs[0];
+    currentTabId = tab.id;
+    chrome.scripting.executeScript({ target: { tabId: tab.id }, files: ['contentScript.js'] }).then(() => {
+      chrome.tabs.sendMessage(tab.id, { action: 'getTables', showHidden: options.showHiddenTables }, tables => {
+        populateList(tables);
+      });
+    });
+  });
+}
+
+function populateList(tables) {
+  const ul = document.getElementById('table-list');
+  ul.innerHTML = '';
+  tables.forEach(t => {
+    const li = document.createElement('li');
+    li.textContent = `Table ${t.id} (${t.rows}\u00d7${t.cols})`;
+    const btn = document.createElement('button');
+    btn.textContent = chrome.i18n.getMessage('preview');
+    btn.dataset.id = t.id;
+    li.appendChild(btn);
+    ul.appendChild(li);
+  });
+}
+
+document.getElementById('table-list').addEventListener('click', e => {
+  if (e.target.tagName === 'BUTTON') {
+    showPreview(parseInt(e.target.dataset.id, 10));
+  }
+});
+
+function showPreview(id) {
+  currentTableId = id;
+  chrome.tabs.sendMessage(currentTabId, { action: 'getTableData', id }, data => {
+    const table = document.getElementById('preview-table');
+    table.innerHTML = '';
+    data.slice(0, 5).forEach(row => {
+      const tr = document.createElement('tr');
+      row.forEach(cell => {
+        const td = document.createElement('td');
+        td.textContent = cell;
+        tr.appendChild(td);
+      });
+      table.appendChild(tr);
+    });
+    document.getElementById('preview-container').hidden = false;
+  });
+  chrome.tabs.sendMessage(currentTabId, { action: 'highlightTable', id });
+}
+
+document.getElementById('download').textContent = chrome.i18n.getMessage('downloadCsv');
+document.getElementById('copy').textContent = chrome.i18n.getMessage('copyExcel');
+
+document.getElementById('download').addEventListener('click', () => exportTable('csv'));
+document.getElementById('copy').addEventListener('click', () => exportTable('tsv'));
+
+function exportTable(type) {
+  if (currentTableId == null) return;
+  chrome.tabs.sendMessage(currentTabId, { action: 'getTableData', id: currentTableId }, data => {
+    if (type === 'csv') {
+      const csv = encodeCsv(data, options.delimiter, options.lineEnding);
+      const filename = 'table-' + new Date().toISOString().slice(0, 10) + '.csv';
+      downloadCsv(filename, csv);
+    } else {
+      const tsv = encodeCsv(data, '\t', options.lineEnding);
+      copyText(tsv);
+    }
+  });
+}
+
+loadOptions().then(requestTables);

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const { encodeCsv } = require('../util');
+
+const data = [['a', 'b,c', 'd"e'], ['1', '2', '3']];
+const expected = 'a,"b,c","d""e"\n1,2,3';
+assert.strictEqual(encodeCsv(data), expected);
+console.log('encodeCsv test passed');

--- a/util.js
+++ b/util.js
@@ -1,0 +1,47 @@
+function escapeCsvCell(cell, delimiter) {
+  cell = cell.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const needsQuote = cell.includes('"') || cell.includes(delimiter) || cell.includes('\n');
+  cell = cell.replace(/"/g, '""');
+  return needsQuote ? `"${cell}"` : cell;
+}
+
+function encodeCsv(data, delimiter = ',', lineEnd = '\n') {
+  return data
+    .map(row => row.map(cell => escapeCsvCell(String(cell ?? ''), delimiter)).join(delimiter))
+    .join(lineEnd);
+}
+
+function downloadCsv(filename, csvText) {
+  const blobUrl = URL.createObjectURL(new Blob(['\uFEFF' + csvText], { type: 'text/csv' }));
+  chrome.downloads.download({ url: blobUrl, filename }, () => {
+    setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+  });
+}
+
+function copyText(text) {
+  return navigator.clipboard.writeText(text).catch(() => {
+    return new Promise(resolve => {
+      chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+        chrome.scripting.executeScript(
+          {
+            target: { tabId: tab.id },
+            func: t => {
+              const textarea = document.createElement('textarea');
+              textarea.value = t;
+              document.body.appendChild(textarea);
+              textarea.select();
+              document.execCommand('copy');
+              textarea.remove();
+            },
+            args: [text]
+          },
+          () => resolve()
+        );
+      });
+    });
+  });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { encodeCsv, escapeCsvCell };
+}


### PR DESCRIPTION
## Summary
- implement Chrome extension to detect tables and export them
- add popup UI, options page and util functions
- provide simple unit test for encodeCsv

## Testing
- `node test/run.js`


------
https://chatgpt.com/codex/tasks/task_e_6842a68c8f9c832fb56845142981fb52